### PR TITLE
use `ixmp.TimeSeries.timeseries()` filters, make IamDataFrame from pandas.DataFrame

### DIFF
--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -537,8 +537,7 @@ class IamDataFrame(object):
                 meta = meta[keep_col_match(meta[col], values)]
             return return_df(meta, display, idx_cols)
 
-    def to_excel(self, excel_writer, filters={}, exclude_cat=[],
-                 sheet_name='data', index=False, **kwargs):
+    def to_excel(self, excel_writer, sheet_name='data', index=False, **kwargs):
         """Write timeseries data to Excel using the IAMC template convention
         (wrapper for `pandas.DataFrame.to_excel()`)
 
@@ -546,17 +545,12 @@ class IamDataFrame(object):
         ----------
         excel_writer: string or ExcelWriter object
              file path or existing ExcelWriter
-        filters: dict, optional
-            filter by model, scenario, region, variable, level, year, category
-            see function _select() for details
-        exclude_cat: None or list of strings, default []
-            exclude all scenarios from the listed categories
         sheet_name: string, default 'data'
             name of the sheet that will contain the (filtered) IamDataFrame
         index: boolean, default False
             write row names (index)
         """
-        df = self.filter(filters, exclude_cat).timeseries().reset_index()
+        df = self.timeseries().reset_index()
         df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -65,7 +65,8 @@ class IamDataFrame(object):
     (including validation of values, completeness of variables provided)
     as well as a number of visualization and plotting tools."""
 
-    def __init__(self, data, regions=None, **kwargs):
+    def __init__(self, data, regions=None, variables=None, units=None,
+                 years=None, **kwargs):
         """Initialize an instance of an IamDataFrame
 
         Parameters
@@ -73,14 +74,21 @@ class IamDataFrame(object):
         data: ixmp.TimeSeries, ixmp.Scenario, pandas.DataFrame or data file
             an instance of an TimeSeries or Scenario (requires `ixmp`),
             or pandas.DataFrame or data file with IAMC-format data columns
-        regions: list
-            list of regions to be imported
+        regions : list of strings
+            filter by regions
+        variables : list of strings
+            filter by variables (only with ixmp objects)
+        units : list of strings
+            filter by units (only with ixmp objects)
+        years : list of integers
+            filter by years (only with ixmp objects)
         """
         # import data from pandas.DataFrame or read from source
         if isinstance(data, pd.DataFrame):
             self.data = format_data(data)
         elif has_ix and isinstance(data, ixmp.TimeSeries):
-            self.data = read_ix(data, regions)
+            self.data = read_ix(data, regions=regions, variables=variables,
+                                units=units, years=years)
         else:
             self.data = read_data(data, regions, **kwargs)
 
@@ -93,7 +101,8 @@ class IamDataFrame(object):
         self.cat_color = {'uncategorized': 'white', 'exclude': 'black'}
         self.col_count = 0
 
-    def append(self, other, regions=None, **kwargs):
+    def append(self, other, regions=None, variables=None, units=None,
+               years=None, **kwargs):
         """Import or read timeseries data and append to IamDataFrame
 
         Parameters
@@ -101,15 +110,22 @@ class IamDataFrame(object):
         other: ixmp.TimeSeries, ixmp.Scenario, pandas.DataFrame or data file
             an instance of an TimeSeries or Scenario (requires `ixmp`),
             or pandas.DataFrame or data file with IAMC-format data columns
-        regions: list
-            list of regions to be imported
+        regions : list of strings
+            filter by regions
+        variables : list of strings
+            filter by variables (only with ixmp objects)
+        units : list of strings
+            filter by units (only with ixmp objects)
+        years : list of integers
+            filter by years (only with ixmp objects)
         """
         new = copy.deepcopy(self)
 
         if isinstance(other, pd.DataFrame):
             df = format_data(other)
         elif has_ix and isinstance(other, ixmp.TimeSeries):
-            df = read_ix(other, regions)
+            df = read_ix(other, regions=regions, variables=variables,
+                         units=units, years=years)
         elif os.path.isfile(other):
             df = read_data(other, regions, **kwargs)
         else:
@@ -724,9 +740,8 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        with_metadata : bool, optional
-           if True, join data existing metadata 
-           default: False
+        with_metadata : bool, default False
+           if True, join data with existing metadata
         """
         df = self.data
         if with_metadata:

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -537,7 +537,8 @@ class IamDataFrame(object):
                 meta = meta[keep_col_match(meta[col], values)]
             return return_df(meta, display, idx_cols)
 
-    def to_excel(self, excel_writer, filters={}, exclude_cat=[], **kwargs):
+    def to_excel(self, excel_writer, filters={}, exclude_cat=[],
+                 sheet_name='data', index=False, **kwargs):
         """Write timeseries data to Excel using the IAMC template convention
         (wrapper for `pandas.DataFrame.to_excel()`)
 
@@ -550,17 +551,15 @@ class IamDataFrame(object):
             see function _select() for details
         exclude_cat: None or list of strings, default []
             exclude all scenarios from the listed categories
+        sheet_name: string, default 'data'
+            name of the sheet that will contain the (filtered) IamDataFrame
+        index: boolean, default False
+            write row names (index)
         """
         df = self.timeseries(filters, exclude_cat).reset_index()
         df.columns = [str.title(i) if type(i) == str else i
                       for i in df.columns]
-
-        defaults = {'sheet_name': 'data', 'index': False}
-        for key, value in defaults.items():
-            if key not in kwargs:
-                kwargs[key] = value
-
-        df.to_excel(excel_writer, **kwargs)
+        df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -556,9 +556,8 @@ class IamDataFrame(object):
         index: boolean, default False
             write row names (index)
         """
-        df = self.timeseries(filters, exclude_cat).reset_index()
-        df.columns = [str.title(i) if type(i) == str else i
-                      for i in df.columns]
+        df = self.filter(filters, exclude_cat).timeseries().reset_index()
+        df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 
     def interpolate(self, year, exclude_cat=['exclude']):

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -538,7 +538,7 @@ class IamDataFrame(object):
             return return_df(meta, display, idx_cols)
 
     def to_excel(self, excel_writer, filters={}, exclude_cat=[], **kwargs):
-        """Write timeseries data to Excel
+        """Write timeseries data to Excel using the IAMC template convention
         (wrapper for `pandas.DataFrame.to_excel()`)
 
         Parameters
@@ -554,7 +554,13 @@ class IamDataFrame(object):
         df = self.timeseries(filters, exclude_cat).reset_index()
         df.columns = [str.title(i) if type(i) == str else i
                       for i in df.columns]
-        df.to_excel(excel_writer, kwargs, index=False, sheet_name='data')
+
+        defaults = {'sheet_name': 'data', 'index': False}
+        for key, value in defaults.items():
+            if key not in kwargs:
+                kwargs[key] = value
+
+        df.to_excel(excel_writer, **kwargs)
 
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -101,8 +101,8 @@ class IamDataFrame(object):
         self.cat_color = {'uncategorized': 'white', 'exclude': 'black'}
         self.col_count = 0
 
-    def append(self, other, regions=None, variables=None, units=None,
-               years=None, **kwargs):
+    def append(self, other, inplace=False, regions=None, variables=None,
+               units=None, years=None, **kwargs):
         """Import or read timeseries data and append to IamDataFrame
 
         Parameters
@@ -111,6 +111,8 @@ class IamDataFrame(object):
         pandas.DataFrame or data file
             an IamDataFrame, TimeSeries or Scenario (requires `ixmp`),
             or pandas.DataFrame or data file with IAMC-format data columns
+        inplace : bool, default False
+            if True, do operation inplace and return None
         regions : list of strings
             filter by regions
         variables : list of strings
@@ -145,7 +147,11 @@ class IamDataFrame(object):
 
         # add new data
         new.data = new.data.append(df).reset_index(drop=True)
-        return new
+
+        if inplace:
+            self = new
+        else:
+            return new
 
     def export_metadata(self, path):
         """Export metadata to Excel

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -309,20 +309,20 @@ class IamDataFrame(object):
         else:
             return df_pivot
 
-    def timeseries(self, filters={}, exclude_cat=['exclude']):
+    def timeseries(self, index=True):
         """Returns a dataframe in the standard IAMC format
 
         Parameters
         ----------
-        filters: dict, optional
-            filter by model, scenario, region, variable, level, year, category
-            see function _select() for details
-        exclude_cat: list of strings, default ['exclude']
-            exclude all scenarios from the listed categories from validation
+        index: boolean, default True
+            use IAMC columns as index (if True) or no index (if False)
         """
-        return self._select(filters, exclude_cat=exclude_cat
-                            ).pivot_table(index=iamc_idx_cols,
-                                          columns='year')['value']
+        df = self.data.pivot_table(index=iamc_idx_cols,
+                                   columns='year')['value']
+        if index is not True:
+            df.reset_index(inplace=True)
+
+        return df
 
     def validate(self, criteria, filters={}, exclude_cat=['exclude'],
                  exclude=False, silent=False, display='heatmap'):

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -536,6 +536,23 @@ class IamDataFrame(object):
                 meta = meta[keep_col_match(meta[col], values)]
             return return_df(meta, display, idx_cols)
 
+    def to_excel(self, excel_writer, filters={}, exclude_cat=[], **kwargs):
+        """Write timeseries data to Excel
+        (wrapper for `pandas.DataFrame.to_excel()`)
+
+        Parameters
+        ----------
+        excel_writer: string or ExcelWriter object
+             file path or existing ExcelWriter
+        filters: dict, optional
+            filter by model, scenario, region, variable, level, year, category
+            see function _select() for details
+        exclude_cat: None or list of strings, default []
+            exclude all scenarios from the listed categories
+        """
+        self.timeseries(filters, exclude_cat)\
+            .reset_index().to_excel(excel_writer, kwargs, index=False)
+
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -309,20 +309,11 @@ class IamDataFrame(object):
         else:
             return df_pivot
 
-    def timeseries(self, index=True):
+    def timeseries(self):
         """Returns a dataframe in the standard IAMC format
-
-        Parameters
-        ----------
-        index: boolean, default True
-            use IAMC columns as index (if True) or no index (if False)
         """
-        df = self.data.pivot_table(index=iamc_idx_cols,
+        return self.data.pivot_table(index=iamc_idx_cols,
                                    columns='year')['value']
-        if index is not True:
-            df.reset_index(inplace=True)
-
-        return df
 
     def validate(self, criteria, filters={}, exclude_cat=['exclude'],
                  exclude=False, silent=False, display='heatmap'):
@@ -550,7 +541,7 @@ class IamDataFrame(object):
         index: boolean, default False
             write row names (index)
         """
-        df = self.timeseries(index=False)
+        df = self.timeseries().reset_index()
         df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -509,7 +509,8 @@ class IamDataFrame(object):
         name: str, default None
             if df is series, name of new metadata column
         filters: dict, optional
-            filter by model, scenario or category
+            filter by model, scenario, region, variable, level, year, category
+            see function _select() for details
         idx_cols: list of str, default ['model', 'scenario']
             columns that are set as index of the returned dataframe (if 'list')
         exclude_cat: None or list of strings, default ['exclude']

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -684,9 +684,8 @@ class IamDataFrame(object):
              - 'year': takes an integer, a list of integers or a range
                 note that the last year of a range is not included,
                 so ``range(2010,2015)`` is interpreted as ``[2010, ..., 2014]``
-        inplace : bool, optional
-            if True, operate on this object, otherwise return a copy
-            default: False
+        inplace : bool, default False
+            if True, do operation inplace and return None
         """
         keep = self._filter_columns(filters)
         ret = copy.deepcopy(self) if not inplace else self
@@ -697,7 +696,8 @@ class IamDataFrame(object):
             names=('model', 'scenario')
         )
         ret._meta = ret._meta.loc[idx]
-        return ret
+        if not inplace:
+            return ret
 
     def head(self, *args, **kwargs):
         """Identical to pd.DataFrame.head() operating on data"""

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -550,7 +550,7 @@ class IamDataFrame(object):
         index: boolean, default False
             write row names (index)
         """
-        df = self.timeseries().reset_index()
+        df = self.timeseries(index=False)
         df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -755,7 +755,7 @@ class IamDataFrame(object):
 # %% auxiliary function for reading data from snapshot file
 
 
-def read_ix(ix, regions=None):
+def read_ix(ix, regions=None, variables=None, units=None, years=None):
     """Read timeseries data from an ix object
 
     Parameters
@@ -765,20 +765,14 @@ def read_ix(ix, regions=None):
     regions: list
         list of regions to be loaded from the database snapshot
     """
-    if not has_ix:
-        error = 'this option depends on the ixmp package'
-        raise SystemError(error)
     if isinstance(ix, ixmp.TimeSeries):
-        df = ix.timeseries()
+        df = ix.timeseries(iamc=False, regions=regions, variables=variables,
+                           units=units, years=years)
         df['model'] = ix.model
         df['scenario'] = ix.scenario
     else:
         error = 'arg ' + ix + ' not recognized as valid ixmp class'
         raise ValueError(error)
-
-    # TODO this should be moved to the filters of the function ix.timeseries()
-    if regions is not None:
-        df = df[df.region.isin(regions)]
 
     return df
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -70,36 +70,27 @@ class IamDataFrame(object):
 
         Parameters
         ----------
-        data: pyam-analyis.IamDataFrame, ixmp.TimeSeries, ixmp.Scenario
-        or data file
-            an instance of an IamDataFrame, TimeSeries or Scenario
+        data: ixmp.TimeSeries, ixmp.Scenario or data file
+            an instance of an TimeSeries or Scenario
             (these two option require the 'ixmp' package as a dependency)
             or a file with IAMC-style data
         regions: list
             list of regions to be imported
         """
-        # copy-constructor
-        if isinstance(data, IamDataFrame):
-            self.data = data.data
-            self._meta = data._meta
-            self.cat_color = data.cat_color
-            self.col_count = data.col_count
-
-        # read data from source
+        # import data from pandas.DataFrame or read from source
+        if has_ix and isinstance(data, ixmp.TimeSeries):
+            self.data = read_ix(data, regions)
         else:
-            if has_ix and isinstance(data, ixmp.TimeSeries):
-                self.data = read_ix(data, regions)
-            else:
-                self.data = read_data(data, regions, **kwargs)
+            self.data = read_data(data, regions, **kwargs)
 
-            # define a dataframe for categorization and other meta-data
-            self._meta = return_index(self.data, mod_scen,
-                                      drop_duplicates=True)
-            self.reset_category(True)
+        # define a dataframe for categorization and other meta-data
+        self._meta = return_index(self.data, mod_scen,
+                                  drop_duplicates=True)
+        self.reset_category(True)
 
-            # define a dictionary for category-color mapping
-            self.cat_color = {'uncategorized': 'white', 'exclude': 'black'}
-            self.col_count = 0
+        # define a dictionary for category-color mapping
+        self.cat_color = {'uncategorized': 'white', 'exclude': 'black'}
+        self.col_count = 0
 
     def append(self, other, regions=None):
         """Read timeseries data and append to IamDataFrame
@@ -112,7 +103,7 @@ class IamDataFrame(object):
         regions: list
             list of regions to be imported
         """
-        new = IamDataFrame(data=self)
+        new = copy.deepcopy(self)
 
         if has_ix and isinstance(other, ixmp.TimeSeries):
             df = read_ix(other, regions)

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -551,8 +551,10 @@ class IamDataFrame(object):
         exclude_cat: None or list of strings, default []
             exclude all scenarios from the listed categories
         """
-        self.timeseries(filters, exclude_cat)\
-            .reset_index().to_excel(excel_writer, kwargs, index=False)
+        df = self.timeseries(filters, exclude_cat).reset_index()
+        df.columns = [str.title(i) if type(i) == str else i
+                      for i in df.columns]
+        df.to_excel(excel_writer, kwargs, index=False, sheet_name='data')
 
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -149,7 +149,8 @@ class IamDataFrame(object):
         new.data = new.data.append(df).reset_index(drop=True)
 
         if inplace:
-            self = new
+            self.data = new.data
+            self._meta = new._meta
         else:
             return new
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -40,7 +40,7 @@ def test_timeseries(test_ia):
            'years': [2005, 2010], 'value': [1, 6]}
     exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
                                         columns=['years'], values='value')
-    obs = test_ia.timeseries({'variable': 'Primary Energy'})
+    obs = test_ia.filter({'variable': 'Primary Energy'}).timeseries()
     npt.assert_array_equal(obs, exp)
 
 
@@ -124,5 +124,5 @@ def test_interpolate():
            'years': [2005, 2007, 2010], 'value': [1, 3, 6]}
     exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
                                         columns=['years'], values='value')
-    obs = df.timeseries({'variable': 'Primary Energy'})
+    obs = df.filter({'variable': 'Primary Energy'}).timeseries()
     npt.assert_array_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,7 +90,10 @@ def test_category_pass():
 
 
 def test_load_metadata(test_ia):
-    test_ia.load_metadata(os.path.join(here, 'testing_metadata.xlsx'))
+    with pytest.warns(Warning) as record:
+        test_ia.load_metadata(os.path.join(here, 'testing_metadata.xlsx'))
+    assert len(record) == 1
+
     obs = test_ia.metadata()
     dct = {'model': ['test_model'], 'scenario': ['test_scenario'],
            'category': ['imported']}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,6 +44,12 @@ def test_timeseries(test_ia):
     npt.assert_array_equal(obs, exp)
 
 
+def test_read_pandas():
+    df = pd.read_csv(data_path)
+    ia = IamDataFrame(df)
+    assert ia.variables() == ['Primary Energy', 'Primary Energy|Coal']
+
+
 def test_validate_pass(test_ia):
     assert test_ia.validate(criteria='Primary Energy', exclude=True) is None
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -93,6 +93,7 @@ def test_load_metadata(test_ia):
     with pytest.warns(Warning) as record:
         test_ia.load_metadata(os.path.join(here, 'testing_metadata.xlsx'))
     assert len(record) == 1
+    assert str(record[0].message) == 'overwriting 1 metadata entry'
 
     obs = test_ia.metadata()
     dct = {'model': ['test_model'], 'scenario': ['test_scenario'],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,6 +35,15 @@ def test_variable_unit(test_ia):
     npt.assert_array_equal(test_ia.variables(include_units=True), exp)
 
 
+def test_timeseries(test_ia):
+    dct = {'model': ['test_model'] * 2, 'scenario': ['test_scenario'] * 2,
+           'years': [2005, 2010], 'value': [1, 6]}
+    exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
+                                        columns=['years'], values='value')
+    obs = test_ia.timeseries({'variable': 'Primary Energy'})
+    npt.assert_array_equal(obs, exp)
+
+
 def test_validate_pass(test_ia):
     assert test_ia.validate(criteria='Primary Energy', exclude=True) is None
 

--- a/tutorial/pyam_first_steps.ipynb
+++ b/tutorial/pyam_first_steps.ipynb
@@ -20,7 +20,7 @@
     "see [data.ene.iiasa.ac.at/database](http://data.ene.iiasa.ac.at/database/) for more information.\n",
     "\n",
     "\n",
-    "| **model**           | **scenario**  | **region** | **variable**   | **unit** | **2005** | **2010** | **2015** |\n",
+    "| **Model**           | **Scenario**  | **Region** | **Variable**   | **Unit** | **2005** | **2010** | **2015** |\n",
     "|---------------------|---------------|------------|----------------|----------|----------|----------|----------|\n",
     "| MESSAGE V.4         | AMPERE3-Base  | World      | Primary Energy | EJ/y     | 454.5    |\t479.6    | ...      |\n",
     "| ...                 | ...           | ...        | ...            | ...      | ...      | ...      | ...      |\n",
@@ -33,6 +33,7 @@
     "0. Display of timeseries data as dataframe and visualization using simple plotting functions.\n",
     "0. Evaluating the model data and executing a range of diagnostic checks to identify data outliers.\n",
     "0. Categorization of scenarios according to timeseries data.\n",
+    "0. Exporting data to Excel\n",
     "\n",
     "\n",
     "## Tutorial data\n",
@@ -553,13 +554,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing data to Excel\n",
+    "\n",
+    "The IamDataFrame can be directly exported to Excel in the standard IAMC format.\n",
+    "This feature is based on [pandas.DataFrame.to_excel()](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html) and can use any keyword arguments of that function."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "df.to_excel('tutorial_export.xlsx')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR increases integration with pandas: IamDataFrames can now be initialized directly from a pandas.DataFrame, and `append()` also takes DataFrames as an argument. IamDataFrame can now also be appended directly to another IamDataFrame.

This PR also implements full filtering when loading timeseries data from an `ixmp.TimeSeries` object.